### PR TITLE
Filter out archived PRs

### DIFF
--- a/pullBar/GitHub/GitHubClient.swift
+++ b/pullBar/GitHub/GitHubClient.swift
@@ -29,7 +29,7 @@ public class GitHubClient {
             .accept("application/json")
         ]
         
-        let graphQlQuery = buildGraphQlQuery(queryString: "is:open is:pr assignee:\(githubUsername)")
+        let graphQlQuery = buildGraphQlQuery(queryString: "is:open is:pr assignee:\(githubUsername) archived:false")
         
         let parameters = [
             "query": graphQlQuery,
@@ -60,7 +60,7 @@ public class GitHubClient {
             .authorization(bearerToken: githubToken),
             .accept("application/json")
         ]
-        let graphQlQuery = buildGraphQlQuery(queryString: "is:open is:pr author:\(githubUsername)")
+        let graphQlQuery = buildGraphQlQuery(queryString: "is:open is:pr author:\(githubUsername) archived:false")
         
         let parameters = [
             "query": graphQlQuery,
@@ -90,7 +90,7 @@ public class GitHubClient {
             .authorization(bearerToken: githubToken),
             .accept("application/json")
         ]
-        let graphQlQuery = buildGraphQlQuery(queryString: "is:open is:pr review-requested:\(githubUsername)")
+        let graphQlQuery = buildGraphQlQuery(queryString: "is:open is:pr review-requested:\(githubUsername) archived:false")
         
         let parameters = [
             "query": graphQlQuery,


### PR DESCRIPTION
Just discovered this app. Absolutely love it.

I want to be able to monitor stuff I created though, and I have this PR against an archived repo that will live here forever if I have that enabled. I don't expect anyone will miss archived stuff disappearing?

<img width="546" alt="image" src="https://github.com/menubar-apps/PullBar/assets/4539332/1c816dab-e2b2-4b27-bd0d-3850de3fe97b">
