### PR TITLE
Fix counter showing nothing for hidden sections

### DIFF
--- a/pullBar/AppDelegate.swift
+++ b/pullBar/AppDelegate.swift
@@ -86,8 +86,14 @@ extension AppDelegate {
 
 
         let group = DispatchGroup()
-        
-        if Defaults[.showAssigned] {
+
+        // The counter can point at a section that isn't displayed.
+        let counterType = Defaults[.counterType]
+        let needAssigned  = Defaults[.showAssigned]  || counterType == .assigned
+        let needCreated   = Defaults[.showCreated]   || counterType == .created
+        let needRequested = Defaults[.showRequested] || counterType == .reviewRequested
+
+        if needAssigned {
             group.enter()
             ghClient.getAssignedPulls() { pulls in
                 assignedPulls?.append(contentsOf: pulls)
@@ -95,7 +101,7 @@ extension AppDelegate {
             }
         }
 
-        if Defaults[.showCreated] {
+        if needCreated {
             group.enter()
             ghClient.getCreatedPulls() { pulls in
                 createdPulls?.append(contentsOf: pulls)
@@ -103,7 +109,7 @@ extension AppDelegate {
             }
         }
 
-        if Defaults[.showRequested] {
+        if needRequested {
             group.enter()
             ghClient.getReviewRequestedPulls() { pulls in
                 reviewRequestedPulls?.append(contentsOf: pulls)
@@ -114,13 +120,14 @@ extension AppDelegate {
         group.notify(queue: .main) {
             
             if let assignedPulls = assignedPulls, let createdPulls = createdPulls, let reviewRequestedPulls = reviewRequestedPulls {
-                self.statusBarItem.button?.title = ""
+                switch counterType {
+                case .assigned:        self.statusBarItem.button?.title = assignedPulls.isEmpty ? "" : String(assignedPulls.count)
+                case .created:         self.statusBarItem.button?.title = createdPulls.isEmpty ? "" : String(createdPulls.count)
+                case .reviewRequested: self.statusBarItem.button?.title = reviewRequestedPulls.isEmpty ? "" : String(reviewRequestedPulls.count)
+                case .none:            self.statusBarItem.button?.title = ""
+                }
 
                 if Defaults[.showAssigned] && !assignedPulls.isEmpty {
-                    if Defaults[.counterType] == .assigned {
-                        self.statusBarItem.button?.title = String(assignedPulls.count)
-                    }
-
                     self.menu.addItem(NSMenuItem(title: "Assigned (\(assignedPulls.count))", action: nil, keyEquivalent: ""))
                     for pull in assignedPulls {
                         self.menu.addItem(self.createMenuItem(pull: pull))
@@ -129,10 +136,6 @@ extension AppDelegate {
                 }
                 
                 if Defaults[.showCreated] && !createdPulls.isEmpty {
-                    if Defaults[.counterType] == .created {
-                        self.statusBarItem.button?.title = String(createdPulls.count)
-                    }
-
                     self.menu.addItem(NSMenuItem(title: "Created (\(createdPulls.count))", action: nil, keyEquivalent: ""))
                     for pull in createdPulls {
                         self.menu.addItem(self.createMenuItem(pull: pull))
@@ -141,10 +144,6 @@ extension AppDelegate {
                 }
 
                 if Defaults[.showRequested] && !reviewRequestedPulls.isEmpty {
-                    if Defaults[.counterType] == .reviewRequested {
-                        self.statusBarItem.button?.title = String(reviewRequestedPulls.count)
-                    }
-
                     self.menu.addItem(NSMenuItem(title: "Review Requested (\(reviewRequestedPulls.count))", action: nil, keyEquivalent: ""))
                     for pull in reviewRequestedPulls {
                         self.menu.addItem(self.createMenuItem(pull: pull))

--- a/pullBar/GitHub/GitHubClient.swift
+++ b/pullBar/GitHub/GitHubClient.swift
@@ -18,6 +18,7 @@ public class GitHubClient {
         
         if (Defaults[.githubUsername] == "" || githubToken == "") {
             completion([Edge]())
+            return
         }
         
         let headers: HTTPHeaders = [
@@ -50,6 +51,7 @@ public class GitHubClient {
         
         if (Defaults[.githubUsername] == "" || githubToken == "") {
             completion([Edge]())
+            return
         }
         
         let headers: HTTPHeaders = [
@@ -80,6 +82,7 @@ public class GitHubClient {
     func getReviewRequestedPulls(completion:@escaping (([Edge]) -> Void)) -> Void {
         if (Defaults[.githubUsername] == "" || githubToken == "") {
             completion([Edge]())
+            return
         }
         
         let headers: HTTPHeaders = [


### PR DESCRIPTION
## Problem

### The counter does nothing for a section you don't display

`statusBarItem.button?.title` is assigned inside each section's render block:

```swift
if Defaults[.showAssigned] && !assignedPulls.isEmpty {
    if Defaults[.counterType] == .assigned {
        self.statusBarItem.button?.title = String(assignedPulls.count)
    }
```

and the fetch is gated on the same toggle:

```swift
if Defaults[.showAssigned] {
    ghClient.getAssignedPulls() { ... }
}
```

So selecting `assigned` for the counter while the assigned section is unchecked shows no number at all — the data is never requested, and the assignment never runs. Every counter option is selectable from Preferences regardless of which sections are enabled, so the two settings appear independent but aren't.

**To reproduce**

1. Preferences → Pull Requests → uncheck **assigned**
2. Preferences → Counter → select **assigned**
3. Menu bar shows no number

Same for `created` and `review requested`.

## Fix

- Fetch a category when its section is shown **or** the counter points at it.
- Assign the title once, outside the rendering, rather than inside each section's render block.

## Also included

The missing `return` after the empty-credential guard, in all three fetch methods:

```swift
if (Defaults[.githubUsername] == "" || githubToken == "") {
    completion([Edge]())
    return   // added
}
```

Without it the early `completion([Edge]())` runs and then the request proceeds anyway, so the completion fires twice — two `group.leave()` calls against one `enter()`, which traps. Not reachable today, because `refreshMenu()` checks the same condition before calling in, but the guard reads as an early return and does not behave as one.

## Verification

Tested against an account with 18 assigned and 40 created pull requests.

With `counterType = assigned` and the assigned section unchecked: the menu bar now shows `18` while the dropdown lists only Created. Before the change it showed nothing.

Builds clean on Xcode 26 / macOS 26, no new warnings.
