### PR TITLE
Keep the menu populated during a background refresh

### DIFF
--- a/pullBar/AppDelegate.swift
+++ b/pullBar/AppDelegate.swift
@@ -72,9 +72,9 @@ extension AppDelegate {
     @objc
     func refreshMenu() {
         NSLog("Refreshing menu")
-        self.menu.removeAllItems()
 
         if (Defaults[.githubUsername] == "" || githubToken == "") {
+            self.menu.removeAllItems()
             addMenuFooterItems()
             return
         }
@@ -120,6 +120,10 @@ extension AppDelegate {
         group.notify(queue: .main) {
             
             if let assignedPulls = assignedPulls, let createdPulls = createdPulls, let reviewRequestedPulls = reviewRequestedPulls {
+                // An empty NSMenu will not open, so hold the previous items until
+                // the new ones are ready to replace them.
+                self.menu.removeAllItems()
+
                 switch counterType {
                 case .assigned:        self.statusBarItem.button?.title = assignedPulls.isEmpty ? "" : String(assignedPulls.count)
                 case .created:         self.statusBarItem.button?.title = createdPulls.isEmpty ? "" : String(createdPulls.count)


### PR DESCRIPTION
Fixes #41.

## Problem

`refreshMenu()` empties the menu before the network requests start, and only repopulates in the `group.notify` callback:

```swift
func refreshMenu() {
    self.menu.removeAllItems()   // menu is now empty

    // ... async requests ...

    group.notify(queue: .main) {
        // repopulated here, seconds later
    }
}
```

macOS will not open an empty `NSMenu` attached to a status item, so clicking the icon during that window does nothing at all.

The window is longer than the issue estimates. Measured on an account with 40 open pull requests and three sections enabled, the gap between `refreshMenu()` and `group.notify` firing was **~10 seconds**:

```
16:03:24  Refreshing menu
16:03:34  notify fired
```

At the 1 minute refresh rate the reporter used, that is roughly a sixth of all clicks landing on a dead icon.

## Fix

Clear inside `group.notify`, immediately before adding the new items, so the menu always holds either the previous data or the fresh data.

## One addition to the suggested fix

The issue proposes moving `removeAllItems()` into `group.notify`. That alone breaks the no-credentials path:

```swift
self.menu.removeAllItems()      // the only clear
if (Defaults[.githubUsername] == "" || githubToken == "") {
    addMenuFooterItems()        // appends
    return
}
```

`addMenuFooterItems()` appends, so with the single clear relocated, that early return would stack another copy of Refresh / Preferences / About / Quit on every refresh — twelve duplicate sets an hour at the default 5 minute rate. This PR clears in both paths.

## Known limitation

The first fetch after launch still shows an empty menu, because there are no previous items to hold on to. Addressing that needs a placeholder item, which felt like a separate change — happy to add it if you'd prefer it here.

## Verification

Refresh rate set to 1 minute, clicked the icon repeatedly across several refresh ticks. The menu opened every time, showing the previous list until the new one swapped in. Before the change, clicks during the fetch did nothing.

Builds clean, no new warnings.

Independent of #42 — same function, different lines. Either can merge first; the second may need a trivial rebase.
