### PR TITLE
feat: Custom queries (categories)

### DIFF
--- a/pullBar/AppDelegate.swift
+++ b/pullBar/AppDelegate.swift
@@ -144,6 +144,12 @@ extension AppDelegate {
         }
 
         group.notify(queue: .main) {
+            // Clear again right before rebuilding: the initial removeAllItems()
+            // runs synchronously at the start of refreshMenu(), but building
+            // happens here asynchronously. If two refreshes overlap, clearing
+            // here ensures the last completion produces a single menu rather
+            // than appending a duplicate set of items.
+            self.menu.removeAllItems()
             self.statusBarItem.button?.title = ""
 
             // Only categories that actually have pull requests are rendered.

--- a/pullBar/AppDelegate.swift
+++ b/pullBar/AppDelegate.swift
@@ -50,8 +50,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         timer?.fire()
         RunLoop.main.add(timer!, forMode: .common)
         NSApp.setActivationPolicy(.accessory)
-        
-        
+
+
         // Insert code here to initialize your application
     }
     
@@ -68,28 +68,36 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSWorkspace.shared.open(sender.representedObject as! URL)
     }
 
-    /// One-time migration of the legacy per-type toggles into the unified
-    /// `categories` list, then reconcile the stored list with the current builtins
-    /// (so builtins added in newer versions show up and their name/filter stay
-    /// authoritative while the user's enabled choice is preserved).
+    /// One-time migration of the legacy per-type toggles and counter choice into
+    /// the user-managed `categories` list and `counterSelection`. Fresh installs
+    /// (no persisted legacy settings) keep the default categories instead.
     func migrateCategoriesIfNeeded() {
-        if !Defaults[.didMigrateCategories] {
-            var categories = Defaults[.categories]
-            let legacyEnabled: [String: Bool] = [
-                SearchCategory.assignedId: Defaults[.showAssigned],
-                SearchCategory.createdId: Defaults[.showCreated],
-                SearchCategory.reviewRequestedId: Defaults[.showRequested],
-            ]
-            for index in categories.indices {
-                if let enabled = legacyEnabled[categories[index].id] {
-                    categories[index].enabled = enabled
-                }
-            }
-            Defaults[.categories] = categories
-            Defaults[.didMigrateCategories] = true
-        }
+        guard Defaults[.categoriesSchemaVersion] < 1 else { return }
+        Defaults[.categoriesSchemaVersion] = 1
 
-        Defaults[.categories] = SearchCategory.reconcile(Defaults[.categories])
+        let userDefaults = UserDefaults.standard
+        let hasLegacySettings = ["showAssigned", "showCreated", "showRequested", "counterType"]
+            .contains { userDefaults.object(forKey: $0) != nil }
+        guard hasLegacySettings else { return }
+
+        // Seed the categories list from the legacy toggles, preserving order.
+        var seeded: [SearchCategory] = []
+        if Defaults[.showAssigned] { seeded.append(BuiltinTemplate.assigned.makeCategory(id: "seed-assigned")) }
+        if Defaults[.showCreated] { seeded.append(BuiltinTemplate.created.makeCategory(id: "seed-created")) }
+        if Defaults[.showRequested] { seeded.append(BuiltinTemplate.reviewRequested.makeCategory(id: "seed-review-requested")) }
+        Defaults[.categories] = seeded
+
+        // Map the legacy counter choice onto the new counter selection.
+        switch Defaults[.legacyCounterType] {
+        case "none":
+            Defaults[.counterSelection] = SearchCategory.counterNone
+        case "assigned":
+            Defaults[.counterSelection] = seeded.first(where: { $0.id == "seed-assigned" })?.id ?? SearchCategory.counterMyTeam
+        case "created":
+            Defaults[.counterSelection] = seeded.first(where: { $0.id == "seed-created" })?.id ?? SearchCategory.counterMyTeam
+        default: // "reviewRequested"
+            Defaults[.counterSelection] = SearchCategory.counterMyTeam
+        }
     }
 
 }
@@ -106,15 +114,31 @@ extension AppDelegate {
         }
 
 
-        let categories = Defaults[.categories].filter { $0.enabled && !$0.filter.trimmingCharacters(in: .whitespaces).isEmpty }
+        let username = Defaults[.githubUsername]
+        let categories = Defaults[.categories].filter {
+            !$0.resolvedFilter(username: username).trimmingCharacters(in: .whitespaces).isEmpty
+        }
+        let counter = Defaults[.counterSelection]
+
         var pullsByCategory: [String: [Edge]] = [:]
+        var myTeamCount: Int? = nil
 
         let group = DispatchGroup()
 
         for category in categories {
             group.enter()
-            ghClient.getPulls(filter: category.resolvedFilter(username: Defaults[.githubUsername])) { pulls in
+            ghClient.getPulls(filter: category.resolvedFilter(username: username)) { pulls in
                 pullsByCategory[category.id, default: []].append(contentsOf: pulls)
+                group.leave()
+            }
+        }
+
+        // "My team" is a counter-only builtin, fetched independently of the list.
+        if counter == SearchCategory.counterMyTeam {
+            group.enter()
+            let filter = SearchCategory.myTeamFilter.replacingOccurrences(of: SearchCategory.usernamePlaceholder, with: username)
+            ghClient.getPulls(filter: filter) { pulls in
+                myTeamCount = pulls.count
                 group.leave()
             }
         }
@@ -126,15 +150,23 @@ extension AppDelegate {
                 let pulls = pullsByCategory[category.id] ?? []
                 if pulls.isEmpty { continue }
 
-                if Defaults[.counterCategoryId] == category.id {
-                    self.statusBarItem.button?.title = String(pulls.count)
-                }
-
                 self.menu.addItem(NSMenuItem(title: "\(category.name) (\(pulls.count))", action: nil, keyEquivalent: ""))
                 for pull in pulls {
                     self.menu.addItem(self.createMenuItem(pull: pull))
                 }
                 self.menu.addItem(.separator())
+            }
+
+            let counterCount: Int
+            if counter == SearchCategory.counterMyTeam {
+                counterCount = myTeamCount ?? 0
+            } else if counter != SearchCategory.counterNone {
+                counterCount = (pullsByCategory[counter] ?? []).count
+            } else {
+                counterCount = 0
+            }
+            if counterCount > 0 {
+                self.statusBarItem.button?.title = String(counterCount)
             }
 
             self.addMenuFooterItems()

--- a/pullBar/AppDelegate.swift
+++ b/pullBar/AppDelegate.swift
@@ -26,8 +26,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var timer: Timer? = nil
     
     func applicationDidFinishLaunching(_ aNotification: Notification) {
+        migrateCategoriesIfNeeded()
+
         NotificationCenter.default.addObserver(self, selector: #selector(AppDelegate.windowClosed), name: NSWindow.willCloseNotification, object: nil)
-        
+
         guard let statusButton = statusBarItem.button else { return }
         let icon = NSImage(named: "git-pull-request")
         let size = NSSize(width: 16, height: 16)
@@ -65,7 +67,31 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func openLink(_ sender: NSMenuItem) {
         NSWorkspace.shared.open(sender.representedObject as! URL)
     }
-    
+
+    /// One-time migration of the legacy per-type toggles into the unified
+    /// `categories` list, then reconcile the stored list with the current builtins
+    /// (so builtins added in newer versions show up and their name/filter stay
+    /// authoritative while the user's enabled choice is preserved).
+    func migrateCategoriesIfNeeded() {
+        if !Defaults[.didMigrateCategories] {
+            var categories = Defaults[.categories]
+            let legacyEnabled: [String: Bool] = [
+                SearchCategory.assignedId: Defaults[.showAssigned],
+                SearchCategory.createdId: Defaults[.showCreated],
+                SearchCategory.reviewRequestedId: Defaults[.showRequested],
+            ]
+            for index in categories.indices {
+                if let enabled = legacyEnabled[categories[index].id] {
+                    categories[index].enabled = enabled
+                }
+            }
+            Defaults[.categories] = categories
+            Defaults[.didMigrateCategories] = true
+        }
+
+        Defaults[.categories] = SearchCategory.reconcile(Defaults[.categories])
+    }
+
 }
 
 extension AppDelegate {
@@ -80,81 +106,38 @@ extension AppDelegate {
         }
 
 
-        var assignedPulls: [Edge]? = []
-        var createdPulls: [Edge]? = []
-        var reviewRequestedPulls: [Edge]? = []
-
+        let categories = Defaults[.categories].filter { $0.enabled && !$0.filter.trimmingCharacters(in: .whitespaces).isEmpty }
+        var pullsByCategory: [String: [Edge]] = [:]
 
         let group = DispatchGroup()
-        
-        if Defaults[.showAssigned] {
-            group.enter()
-            ghClient.getAssignedPulls() { pulls in
-                assignedPulls?.append(contentsOf: pulls)
-                group.leave()
-            }
-        }
 
-        if Defaults[.showCreated] {
+        for category in categories {
             group.enter()
-            ghClient.getCreatedPulls() { pulls in
-                createdPulls?.append(contentsOf: pulls)
-                group.leave()
-            }
-        }
-
-        if Defaults[.showRequested] {
-            group.enter()
-            ghClient.getReviewRequestedPulls() { pulls in
-                reviewRequestedPulls?.append(contentsOf: pulls)
+            ghClient.getPulls(filter: category.resolvedFilter(username: Defaults[.githubUsername])) { pulls in
+                pullsByCategory[category.id, default: []].append(contentsOf: pulls)
                 group.leave()
             }
         }
 
         group.notify(queue: .main) {
-            
-            if let assignedPulls = assignedPulls, let createdPulls = createdPulls, let reviewRequestedPulls = reviewRequestedPulls {
-                self.statusBarItem.button?.title = ""
+            self.statusBarItem.button?.title = ""
 
-                if Defaults[.showAssigned] && !assignedPulls.isEmpty {
-                    if Defaults[.counterType] == .assigned {
-                        self.statusBarItem.button?.title = String(assignedPulls.count)
-                    }
+            for category in categories {
+                let pulls = pullsByCategory[category.id] ?? []
+                if pulls.isEmpty { continue }
 
-                    self.menu.addItem(NSMenuItem(title: "Assigned (\(assignedPulls.count))", action: nil, keyEquivalent: ""))
-                    for pull in assignedPulls {
-                        self.menu.addItem(self.createMenuItem(pull: pull))
-                    }
-                    self.menu.addItem(.separator())
-                }
-                
-                if Defaults[.showCreated] && !createdPulls.isEmpty {
-                    if Defaults[.counterType] == .created {
-                        self.statusBarItem.button?.title = String(createdPulls.count)
-                    }
-
-                    self.menu.addItem(NSMenuItem(title: "Created (\(createdPulls.count))", action: nil, keyEquivalent: ""))
-                    for pull in createdPulls {
-                        self.menu.addItem(self.createMenuItem(pull: pull))
-                    }
-                    self.menu.addItem(.separator())
+                if Defaults[.counterCategoryId] == category.id {
+                    self.statusBarItem.button?.title = String(pulls.count)
                 }
 
-                if Defaults[.showRequested] && !reviewRequestedPulls.isEmpty {
-                    if Defaults[.counterType] == .reviewRequested {
-                        self.statusBarItem.button?.title = String(reviewRequestedPulls.count)
-                    }
-
-                    self.menu.addItem(NSMenuItem(title: "Review Requested (\(reviewRequestedPulls.count))", action: nil, keyEquivalent: ""))
-                    for pull in reviewRequestedPulls {
-                        self.menu.addItem(self.createMenuItem(pull: pull))
-                    }
-                    self.menu.addItem(.separator())
+                self.menu.addItem(NSMenuItem(title: "\(category.name) (\(pulls.count))", action: nil, keyEquivalent: ""))
+                for pull in pulls {
+                    self.menu.addItem(self.createMenuItem(pull: pull))
                 }
-                
-                
-                self.addMenuFooterItems()
+                self.menu.addItem(.separator())
             }
+
+            self.addMenuFooterItems()
         }
     }
     

--- a/pullBar/AppDelegate.swift
+++ b/pullBar/AppDelegate.swift
@@ -146,15 +146,35 @@ extension AppDelegate {
         group.notify(queue: .main) {
             self.statusBarItem.button?.title = ""
 
-            for category in categories {
-                let pulls = pullsByCategory[category.id] ?? []
-                if pulls.isEmpty { continue }
+            // Only categories that actually have pull requests are rendered.
+            let visibleCategories = categories.filter { !(pullsByCategory[$0.id] ?? []).isEmpty }
 
-                self.menu.addItem(NSMenuItem(title: "\(category.name) (\(pulls.count))", action: nil, keyEquivalent: ""))
-                for pull in pulls {
-                    self.menu.addItem(self.createMenuItem(pull: pull))
+            for (index, category) in visibleCategories.enumerated() {
+                let pulls = pullsByCategory[category.id] ?? []
+                let headerTitle = "\(category.name) (\(pulls.count))"
+
+                if category.asSubmenu {
+                    let parent = NSMenuItem(title: headerTitle, action: nil, keyEquivalent: "")
+                    let submenu = NSMenu()
+                    for pull in pulls {
+                        submenu.addItem(self.createMenuItem(pull: pull))
+                    }
+                    parent.submenu = submenu
+                    self.menu.addItem(parent)
+                } else {
+                    self.menu.addItem(NSMenuItem(title: headerTitle, action: nil, keyEquivalent: ""))
+                    for pull in pulls {
+                        self.menu.addItem(self.createMenuItem(pull: pull))
+                    }
                 }
-                self.menu.addItem(.separator())
+
+                // Keep adjacent submenu categories grouped: no separator between
+                // two consecutive submenu items.
+                let next = index + 1 < visibleCategories.count ? visibleCategories[index + 1] : nil
+                let groupedWithNext = category.asSubmenu && (next?.asSubmenu ?? false)
+                if !groupedWithNext {
+                    self.menu.addItem(.separator())
+                }
             }
 
             let counterCount: Int

--- a/pullBar/Extensions/DefaultsExtensions.swift
+++ b/pullBar/Extensions/DefaultsExtensions.swift
@@ -13,54 +13,45 @@ extension Defaults.Keys {
     static let githubUsername = Key<String>("githubUsername", default: "")
     static let githubAdditionalQuery = Key<String>("githubAdditionalQuery", default:"")
 
-    // Legacy keys, kept so existing preferences can be migrated into `categories`.
+    // Legacy keys, kept only so preferences from older versions can be migrated
+    // into `categories` / `counterSelection`.
     static let showAssigned = Key<Bool>("showAssigned", default: false)
     static let showCreated = Key<Bool>("showCreated", default: false)
     static let showRequested = Key<Bool>("showRequested", default: true)
+    static let legacyCounterType = Key<String>("counterType", default: "reviewRequested")
 
-    static let categories = Key<[SearchCategory]>("categories", default: SearchCategory.builtins)
-    static let didMigrateCategories = Key<Bool>("didMigrateCategories", default: false)
+    // Ordered list of categories the user has added. Order determines the order
+    // sections appear in the menubar menu.
+    static let categories = Key<[SearchCategory]>("categories", default: SearchCategory.defaultCategories)
+    // Bumped when the categories storage format changes so migrations run once.
+    static let categoriesSchemaVersion = Key<Int>("categoriesSchemaVersion", default: 0)
 
     static let showAvatar = Key<Bool>("showAvatar", default: false)
     static let showLabels = Key<Bool>("showLabels", default: true)
 
     static let refreshRate = Key<Int>("refreshRate", default: 5)
     static let buildType = Key<BuildType>("buildType", default: .none)
-    // Id of the category whose count is shown next to the menubar icon ("" == none).
-    static let counterCategoryId = Key<String>("counterCategoryId", default: SearchCategory.reviewRequestedId)
+    // Which count is shown next to the menubar icon. Either a special token
+    // (`counterNone` / `counterMyTeam`) or the id of a category.
+    static let counterSelection = Key<String>("counterSelection", default: SearchCategory.counterMyTeam)
 }
 
 extension KeychainKeys {
     static let githubToken: KeychainAccessKey = KeychainAccessKey(key: "githubToken")
 }
 
-/// A named GitHub search that becomes a section in the menu. Builtin categories
-/// ship with the app and cannot be deleted; custom ones are added by the user.
+/// A named GitHub search that becomes a section in the menu. Categories are added
+/// by the user (optionally seeded from a builtin template) and are freely
+/// editable, reorderable, and deletable.
 struct SearchCategory: Codable, Defaults.Serializable, Identifiable, Hashable {
     var id: String
     var name: String
     var filter: String
-    var enabled: Bool
-    var isBuiltin: Bool
-
-    static let assignedId = "assigned"
-    static let createdId = "created"
-    static let reviewRequestedId = "review-requested"
-    static let userReviewRequestedId = "user-review-requested"
 
     /// Placeholder in a filter that is replaced with the configured username at
-    /// query time. Not GitHub search syntax — used so builtin filters can be
+    /// query time. Not GitHub search syntax — used so a template filter can be
     /// stored statically while still resolving to the current user.
     static let usernamePlaceholder = "<username>"
-
-    /// The builtin categories, in display order. `filter` is the fragment that is
-    /// inserted into the standard `is:open is:pr ... archived:false` wrapper.
-    static let builtins: [SearchCategory] = [
-        SearchCategory(id: assignedId, name: "Assigned", filter: "assignee:\(usernamePlaceholder)", enabled: false, isBuiltin: true),
-        SearchCategory(id: createdId, name: "Created", filter: "author:\(usernamePlaceholder)", enabled: false, isBuiltin: true),
-        SearchCategory(id: reviewRequestedId, name: "Review Requested", filter: "review-requested:\(usernamePlaceholder)", enabled: true, isBuiltin: true),
-        SearchCategory(id: userReviewRequestedId, name: "Review Requested (direct)", filter: "user-review-requested:\(usernamePlaceholder)", enabled: false, isBuiltin: true),
-    ]
 
     /// The search filter to actually query with. The `<username>` placeholder is
     /// replaced with the configured username; everything else is passed through
@@ -70,21 +61,55 @@ struct SearchCategory: Codable, Defaults.Serializable, Identifiable, Hashable {
         filter.replacingOccurrences(of: SearchCategory.usernamePlaceholder, with: username)
     }
 
-    /// Reconciles a stored list against the current set of builtins: keeps each
-    /// builtin's name/filter authoritative while preserving the user's enabled
-    /// choice, inserts any builtin that is missing (e.g. added in a new version),
-    /// and keeps custom categories untouched. Builtins are ordered first.
-    static func reconcile(_ stored: [SearchCategory]) -> [SearchCategory] {
-        let reconciledBuiltins = builtins.map { builtin -> SearchCategory in
-            guard let existing = stored.first(where: { $0.id == builtin.id }) else { return builtin }
-            var updated = builtin
-            updated.enabled = existing.enabled
-            return updated
+    // MARK: - Counter selection tokens
+
+    /// No count shown next to the menubar icon.
+    static let counterNone = ""
+    /// Count of team review requests, independent of the categories list.
+    static let counterMyTeam = "__my_team__"
+    /// Filter backing the "My team" counter option.
+    static let myTeamFilter = "review-requested:\(usernamePlaceholder)"
+
+    // MARK: - Defaults
+
+    /// The list a fresh install starts with: the original three builtin types.
+    static let defaultCategories: [SearchCategory] = [
+        BuiltinTemplate.assigned.makeCategory(id: "seed-assigned"),
+        BuiltinTemplate.created.makeCategory(id: "seed-created"),
+        BuiltinTemplate.reviewRequested.makeCategory(id: "seed-review-requested"),
+    ]
+}
+
+/// Predefined starting points offered by the "+" menu on the Categories tab.
+/// Once added they become ordinary categories the user can rename or re-query.
+enum BuiltinTemplate: String, CaseIterable, Identifiable {
+    case assigned
+    case created
+    case reviewRequested
+    case userReviewRequested
+
+    var id: String { rawValue }
+
+    var name: String {
+        switch self {
+        case .assigned: return "Assigned"
+        case .created: return "Created"
+        case .reviewRequested: return "Review Requested"
+        case .userReviewRequested: return "Review Requested (Direct)"
         }
-        let customCategories = stored.filter { category in
-            !builtins.contains(where: { $0.id == category.id })
+    }
+
+    var filter: String {
+        switch self {
+        case .assigned: return "assignee:\(SearchCategory.usernamePlaceholder)"
+        case .created: return "author:\(SearchCategory.usernamePlaceholder)"
+        case .reviewRequested: return "review-requested:\(SearchCategory.usernamePlaceholder)"
+        case .userReviewRequested: return "user-review-requested:\(SearchCategory.usernamePlaceholder)"
         }
-        return reconciledBuiltins + customCategories
+    }
+
+    func makeCategory(id: String) -> SearchCategory {
+        SearchCategory(id: id, name: name, filter: filter)
     }
 }
 
@@ -92,7 +117,7 @@ enum BuildType: String, Defaults.Serializable, CaseIterable, Identifiable {
     case checks
     case commitStatus
     case none
-    
+
     var id: Self { self }
 
     var description: String {
@@ -107,4 +132,3 @@ enum BuildType: String, Defaults.Serializable, CaseIterable, Identifiable {
         }
     }
 }
-

--- a/pullBar/Extensions/DefaultsExtensions.swift
+++ b/pullBar/Extensions/DefaultsExtensions.swift
@@ -47,6 +47,28 @@ struct SearchCategory: Codable, Defaults.Serializable, Identifiable, Hashable {
     var id: String
     var name: String
     var filter: String
+    /// When true the category renders as a single collapsible menu item
+    /// ("Name (12) ▸") whose submenu holds the pull requests, instead of listing
+    /// them inline.
+    var asSubmenu: Bool
+
+    init(id: String, name: String, filter: String, asSubmenu: Bool = false) {
+        self.id = id
+        self.name = name
+        self.filter = filter
+        self.asSubmenu = asSubmenu
+    }
+
+    // Custom decoding so categories stored before `asSubmenu` existed still
+    // decode (missing key defaults to false) rather than failing and wiping the
+    // user's saved list.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        filter = try container.decode(String.self, forKey: .filter)
+        asSubmenu = try container.decodeIfPresent(Bool.self, forKey: .asSubmenu) ?? false
+    }
 
     /// Placeholder in a filter that is replaced with the configured username at
     /// query time. Not GitHub search syntax — used so a template filter can be

--- a/pullBar/Extensions/DefaultsExtensions.swift
+++ b/pullBar/Extensions/DefaultsExtensions.swift
@@ -12,21 +12,80 @@ extension Defaults.Keys {
     static let githubApiBaseUrl = Key<String>("githubApiBaseUrl", default: "https://api.github.com")
     static let githubUsername = Key<String>("githubUsername", default: "")
     static let githubAdditionalQuery = Key<String>("githubAdditionalQuery", default:"")
-    
+
+    // Legacy keys, kept so existing preferences can be migrated into `categories`.
     static let showAssigned = Key<Bool>("showAssigned", default: false)
     static let showCreated = Key<Bool>("showCreated", default: false)
     static let showRequested = Key<Bool>("showRequested", default: true)
-    
+
+    static let categories = Key<[SearchCategory]>("categories", default: SearchCategory.builtins)
+    static let didMigrateCategories = Key<Bool>("didMigrateCategories", default: false)
+
     static let showAvatar = Key<Bool>("showAvatar", default: false)
     static let showLabels = Key<Bool>("showLabels", default: true)
-    
+
     static let refreshRate = Key<Int>("refreshRate", default: 5)
     static let buildType = Key<BuildType>("buildType", default: .none)
-    static let counterType = Key<CounterType>("counterType", default: .reviewRequested)
+    // Id of the category whose count is shown next to the menubar icon ("" == none).
+    static let counterCategoryId = Key<String>("counterCategoryId", default: SearchCategory.reviewRequestedId)
 }
 
 extension KeychainKeys {
     static let githubToken: KeychainAccessKey = KeychainAccessKey(key: "githubToken")
+}
+
+/// A named GitHub search that becomes a section in the menu. Builtin categories
+/// ship with the app and cannot be deleted; custom ones are added by the user.
+struct SearchCategory: Codable, Defaults.Serializable, Identifiable, Hashable {
+    var id: String
+    var name: String
+    var filter: String
+    var enabled: Bool
+    var isBuiltin: Bool
+
+    static let assignedId = "assigned"
+    static let createdId = "created"
+    static let reviewRequestedId = "review-requested"
+    static let userReviewRequestedId = "user-review-requested"
+
+    /// Placeholder in a filter that is replaced with the configured username at
+    /// query time. Not GitHub search syntax — used so builtin filters can be
+    /// stored statically while still resolving to the current user.
+    static let usernamePlaceholder = "<username>"
+
+    /// The builtin categories, in display order. `filter` is the fragment that is
+    /// inserted into the standard `is:open is:pr ... archived:false` wrapper.
+    static let builtins: [SearchCategory] = [
+        SearchCategory(id: assignedId, name: "Assigned", filter: "assignee:\(usernamePlaceholder)", enabled: false, isBuiltin: true),
+        SearchCategory(id: createdId, name: "Created", filter: "author:\(usernamePlaceholder)", enabled: false, isBuiltin: true),
+        SearchCategory(id: reviewRequestedId, name: "Review Requested", filter: "review-requested:\(usernamePlaceholder)", enabled: true, isBuiltin: true),
+        SearchCategory(id: userReviewRequestedId, name: "Review Requested (direct)", filter: "user-review-requested:\(usernamePlaceholder)", enabled: false, isBuiltin: true),
+    ]
+
+    /// The search filter to actually query with. The `<username>` placeholder is
+    /// replaced with the configured username; everything else is passed through
+    /// verbatim, so raw GitHub search syntax (including a literal `@me`) in a
+    /// custom filter is left untouched.
+    func resolvedFilter(username: String) -> String {
+        filter.replacingOccurrences(of: SearchCategory.usernamePlaceholder, with: username)
+    }
+
+    /// Reconciles a stored list against the current set of builtins: keeps each
+    /// builtin's name/filter authoritative while preserving the user's enabled
+    /// choice, inserts any builtin that is missing (e.g. added in a new version),
+    /// and keeps custom categories untouched. Builtins are ordered first.
+    static func reconcile(_ stored: [SearchCategory]) -> [SearchCategory] {
+        let reconciledBuiltins = builtins.map { builtin -> SearchCategory in
+            guard let existing = stored.first(where: { $0.id == builtin.id }) else { return builtin }
+            var updated = builtin
+            updated.enabled = existing.enabled
+            return updated
+        }
+        let customCategories = stored.filter { category in
+            !builtins.contains(where: { $0.id == category.id })
+        }
+        return reconciledBuiltins + customCategories
+    }
 }
 
 enum BuildType: String, Defaults.Serializable, CaseIterable, Identifiable {
@@ -49,25 +108,3 @@ enum BuildType: String, Defaults.Serializable, CaseIterable, Identifiable {
     }
 }
 
-enum CounterType: String, Defaults.Serializable, CaseIterable, Identifiable {
-    case assigned
-    case created
-    case reviewRequested
-    case none
-    
-    var id: Self { self }
-
-    var description: String {
-
-        switch self {
-        case .assigned:
-            return "assigned"
-        case .created:
-            return "created"
-        case .reviewRequested:
-            return "review requested"
-        case .none:
-            return "none"
-        }
-    }
-}

--- a/pullBar/GitHub/GitHubClient.swift
+++ b/pullBar/GitHub/GitHubClient.swift
@@ -14,24 +14,28 @@ public class GitHubClient {
     
     @FromKeychain(.githubToken) var githubToken
     
-    func getAssignedPulls(completion:@escaping (([Edge]) -> Void)) -> Void {
-        
+    /// Fetches open pull requests matching a category's search `filter`, wrapped in
+    /// the standard `is:open is:pr ... archived:false` query along with any
+    /// user-configured additional query.
+    func getPulls(filter: String, completion:@escaping (([Edge]) -> Void)) -> Void {
+
         if (Defaults[.githubUsername] == "" || githubToken == "") {
             completion([Edge]())
+            return
         }
-        
+
         let headers: HTTPHeaders = [
             .authorization(bearerToken: githubToken),
             .accept("application/json")
         ]
-        
-        let graphQlQuery = buildGraphQlQuery(queryString: "is:open is:pr assignee:\(Defaults[.githubUsername]) archived:false \(Defaults[.githubAdditionalQuery])")
-        
+
+        let graphQlQuery = buildGraphQlQuery(queryString: "is:open is:pr \(filter) archived:false \(Defaults[.githubAdditionalQuery])")
+
         let parameters = [
             "query": graphQlQuery,
             "variables":[]
         ] as [String: Any]
-        
+
         AF.request(Defaults[.githubApiBaseUrl] + "/graphql", method: .post, parameters: parameters, encoding: JSONEncoding.default, headers: headers)
             .validate(statusCode: 200..<300)
             .responseDecodable(of: GraphQlSearchResp.self, decoder: GithubDecoder()) { response in
@@ -42,66 +46,6 @@ public class GitHubClient {
                     sendNotification(body: error.localizedDescription)
                     completion([Edge]())
                     print(error)
-                }
-            }
-    }
-    
-    func getCreatedPulls(completion:@escaping (([Edge]) -> Void)) -> Void {
-        
-        if (Defaults[.githubUsername] == "" || githubToken == "") {
-            completion([Edge]())
-        }
-        
-        let headers: HTTPHeaders = [
-            .authorization(bearerToken: githubToken),
-            .accept("application/json")
-        ]
-        let graphQlQuery = buildGraphQlQuery(queryString: "is:open is:pr author:\(Defaults[.githubUsername]) archived:false \(Defaults[.githubAdditionalQuery])")
-        
-        let parameters = [
-            "query": graphQlQuery,
-            "variables":[]
-        ] as [String: Any]
-        
-        AF.request(Defaults[.githubApiBaseUrl] + "/graphql", method: .post, parameters: parameters, encoding: JSONEncoding.default, headers: headers)
-            .validate(statusCode: 200..<300)
-            .responseDecodable(of: GraphQlSearchResp.self, decoder: GithubDecoder()) { response in
-                switch response.result {
-                case .success(let prs):
-                    completion(prs.data.search.edges)
-                case .failure(let error):
-                    sendNotification(body: error.localizedDescription)
-                    print(error)
-                    completion([Edge]())
-                }
-            }
-    }
-    
-    func getReviewRequestedPulls(completion:@escaping (([Edge]) -> Void)) -> Void {
-        if (Defaults[.githubUsername] == "" || githubToken == "") {
-            completion([Edge]())
-        }
-        
-        let headers: HTTPHeaders = [
-            .authorization(bearerToken: githubToken),
-            .accept("application/json")
-        ]
-        let graphQlQuery = buildGraphQlQuery(queryString: "is:open is:pr review-requested:\(Defaults[.githubUsername]) archived:false \(Defaults[.githubAdditionalQuery])")
-        
-        let parameters = [
-            "query": graphQlQuery,
-            "variables":[]
-        ] as [String: Any]
-        
-        AF.request(Defaults[.githubApiBaseUrl] + "/graphql", method: .post, parameters: parameters, encoding: JSONEncoding.default, headers: headers)
-            .validate(statusCode: 200..<300)
-            .responseDecodable(of: GraphQlSearchResp.self, decoder: GithubDecoder()) { response in
-                switch response.result {
-                case .success(let prs):
-                    completion(prs.data.search.edges)
-                case .failure(let error):
-                    sendNotification(body: error.localizedDescription)
-                    completion([Edge]())
                 }
             }
     }

--- a/pullBar/Views/PreferencesView.swift
+++ b/pullBar/Views/PreferencesView.swift
@@ -17,18 +17,18 @@ struct PreferencesView: View {
     @Default(.githubAdditionalQuery) var githubAdditionalQuery
     @FromKeychain(.githubToken) var githubToken
 
-    @Default(.showAssigned) var showAssigned
-    @Default(.showCreated) var showCreated
-    @Default(.showRequested) var showRequested
+    @Default(.categories) var categories
 
     @Default(.showAvatar) var showAvatar
     @Default(.showLabels) var showLabels
 
     @Default(.refreshRate) var refreshRate
     @Default(.buildType) var builtType
-    @Default(.counterType) var counterType
+    @Default(.counterCategoryId) var counterCategoryId
 
     @State private var showGhAlert = false
+    @State private var newCategoryName = ""
+    @State private var newCategoryFilter = ""
 
     @StateObject private var githubTokenValidator = GithubTokenValidator()
 //    @ObservedObject private var launchAtLogin = LaunchAtLogin.observable
@@ -39,12 +39,61 @@ struct PreferencesView: View {
 
         TabView {
             Form {
-                HStack(alignment: .center) {
+                HStack(alignment: .top) {
                     Text("Pull Requests:").frame(width: 120, alignment: .trailing)
-                    VStack(alignment: .leading){
-                        Toggle("assigned", isOn: $showAssigned)
-                        Toggle("created", isOn: $showCreated)
-                        Toggle("review requested", isOn: $showRequested)
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach($categories) { $category in
+                            HStack(alignment: .center, spacing: 6) {
+                                Toggle("", isOn: $category.enabled)
+                                    .labelsHidden()
+                                if category.isBuiltin {
+                                    VStack(alignment: .leading, spacing: 0) {
+                                        Text(category.name)
+                                        Text(category.filter)
+                                            .font(.footnote)
+                                            .foregroundColor(.secondary)
+                                    }
+                                    Spacer()
+                                    Image(systemName: "lock")
+                                        .foregroundColor(.secondary)
+                                        .help("Built-in category, cannot be deleted")
+                                } else {
+                                    TextField("name", text: $category.name)
+                                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                                        .frame(width: 120)
+                                    TextField("filter", text: $category.filter)
+                                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                                        .frame(width: 160)
+                                    Button {
+                                        categories.removeAll { $0.id == category.id }
+                                    } label: {
+                                        Image(systemName: "trash")
+                                    }
+                                    .help("Delete category")
+                                }
+                            }
+                        }
+
+                        Divider().frame(width: 320)
+
+                        HStack(alignment: .center, spacing: 6) {
+                            TextField("name", text: $newCategoryName)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .frame(width: 120)
+                            TextField("filter, e.g. author:@me", text: $newCategoryFilter)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .frame(width: 160)
+                            Button("Add") {
+                                let name = newCategoryName.trimmingCharacters(in: .whitespaces)
+                                let filter = newCategoryFilter.trimmingCharacters(in: .whitespaces)
+                                guard !name.isEmpty, !filter.isEmpty else { return }
+                                categories.append(SearchCategory(id: UUID().uuidString, name: name, filter: filter, enabled: true, isBuiltin: false))
+                                newCategoryName = ""
+                                newCategoryFilter = ""
+                            }
+                            .disabled(newCategoryName.trimmingCharacters(in: .whitespaces).isEmpty
+                                      || newCategoryFilter.trimmingCharacters(in: .whitespaces).isEmpty)
+                        }
                     }
                 }
 
@@ -157,9 +206,10 @@ struct PreferencesView: View {
                             .font(.subheadline)
                             .foregroundColor(.secondary)
                     }
-                    Picker("", selection: $counterType, content: {
-                        ForEach(CounterType.allCases) { bt in
-                            Text(bt.description)
+                    Picker("", selection: $counterCategoryId, content: {
+                        Text("none").tag("")
+                        ForEach(categories) { category in
+                            Text(category.name).tag(category.id)
                         }
                     })
                     .labelsHidden()

--- a/pullBar/Views/PreferencesView.swift
+++ b/pullBar/Views/PreferencesView.swift
@@ -201,9 +201,20 @@ struct PreferencesView: View {
                 .foregroundColor(.secondary)
 
             List {
+                HStack(spacing: 8) {
+                    Color.clear.frame(width: 16, height: 1)
+                    Text("Category name").frame(width: 150, alignment: .leading)
+                    Text("Search query").frame(maxWidth: .infinity, alignment: .leading)
+                    Text("Show in").frame(width: 120, alignment: .leading)
+                    Color.clear.frame(width: 24, height: 1)
+                }
+                .font(.caption)
+                .foregroundColor(.secondary)
+
                 ForEach($categories) { $category in
                     HStack(spacing: 8) {
                         Image(systemName: "line.3.horizontal")
+                            .frame(width: 16)
                             .foregroundColor(.secondary)
                             .help("Drag to reorder")
                         TextField("name", text: $category.name)
@@ -212,12 +223,21 @@ struct PreferencesView: View {
                         TextField("filter, e.g. review-requested:@me", text: $category.filter)
                             .textFieldStyle(RoundedBorderTextFieldStyle())
                             .frame(maxWidth: .infinity)
+                        Picker("", selection: $category.asSubmenu) {
+                            Text("Main menu").tag(false)
+                            Text("Submenu").tag(true)
+                        }
+                        .labelsHidden()
+                        .pickerStyle(MenuPickerStyle())
+                        .frame(width: 120)
+                        .help("Where this category's pull requests appear in the menu")
                         Button {
                             categories.removeAll { $0.id == category.id }
                         } label: {
                             Image(systemName: "trash")
                         }
                         .buttonStyle(BorderlessButtonStyle())
+                        .frame(width: 24)
                         .help("Delete category")
                     }
                     .padding(.vertical, 2)

--- a/pullBar/Views/PreferencesView.swift
+++ b/pullBar/Views/PreferencesView.swift
@@ -24,79 +24,17 @@ struct PreferencesView: View {
 
     @Default(.refreshRate) var refreshRate
     @Default(.buildType) var builtType
-    @Default(.counterCategoryId) var counterCategoryId
+    @Default(.counterSelection) var counterSelection
 
     @State private var showGhAlert = false
-    @State private var newCategoryName = ""
-    @State private var newCategoryFilter = ""
 
     @StateObject private var githubTokenValidator = GithubTokenValidator()
 //    @ObservedObject private var launchAtLogin = LaunchAtLogin.observable
-    
-    @State private var isExpanded: Bool = false
 
     var body: some View {
 
         TabView {
             Form {
-                HStack(alignment: .top) {
-                    Text("Pull Requests:").frame(width: 120, alignment: .trailing)
-                    VStack(alignment: .leading, spacing: 6) {
-                        ForEach($categories) { $category in
-                            HStack(alignment: .center, spacing: 6) {
-                                Toggle("", isOn: $category.enabled)
-                                    .labelsHidden()
-                                if category.isBuiltin {
-                                    VStack(alignment: .leading, spacing: 0) {
-                                        Text(category.name)
-                                        Text(category.filter)
-                                            .font(.footnote)
-                                            .foregroundColor(.secondary)
-                                    }
-                                    Spacer()
-                                    Image(systemName: "lock")
-                                        .foregroundColor(.secondary)
-                                        .help("Built-in category, cannot be deleted")
-                                } else {
-                                    TextField("name", text: $category.name)
-                                        .textFieldStyle(RoundedBorderTextFieldStyle())
-                                        .frame(width: 120)
-                                    TextField("filter", text: $category.filter)
-                                        .textFieldStyle(RoundedBorderTextFieldStyle())
-                                        .frame(width: 160)
-                                    Button {
-                                        categories.removeAll { $0.id == category.id }
-                                    } label: {
-                                        Image(systemName: "trash")
-                                    }
-                                    .help("Delete category")
-                                }
-                            }
-                        }
-
-                        Divider().frame(width: 320)
-
-                        HStack(alignment: .center, spacing: 6) {
-                            TextField("name", text: $newCategoryName)
-                                .textFieldStyle(RoundedBorderTextFieldStyle())
-                                .frame(width: 120)
-                            TextField("filter, e.g. author:@me", text: $newCategoryFilter)
-                                .textFieldStyle(RoundedBorderTextFieldStyle())
-                                .frame(width: 160)
-                            Button("Add") {
-                                let name = newCategoryName.trimmingCharacters(in: .whitespaces)
-                                let filter = newCategoryFilter.trimmingCharacters(in: .whitespaces)
-                                guard !name.isEmpty, !filter.isEmpty else { return }
-                                categories.append(SearchCategory(id: UUID().uuidString, name: name, filter: filter, enabled: true, isBuiltin: false))
-                                newCategoryName = ""
-                                newCategoryFilter = ""
-                            }
-                            .disabled(newCategoryName.trimmingCharacters(in: .whitespaces).isEmpty
-                                      || newCategoryFilter.trimmingCharacters(in: .whitespaces).isEmpty)
-                        }
-                    }
-                }
-
                 HStack(alignment: .center) {
                     Text("Build Information:").frame(width: 120, alignment: .trailing)
                     Picker("", selection: $builtType, content: {
@@ -143,6 +81,9 @@ struct PreferencesView: View {
             .padding(8)
             .frame(maxWidth: .infinity)
             .tabItem{Text("General")}
+
+            categoriesTab
+                .tabItem{Text("Categories")}
 
             Form {
                 HStack(alignment: .center) {
@@ -206,14 +147,20 @@ struct PreferencesView: View {
                             .font(.subheadline)
                             .foregroundColor(.secondary)
                     }
-                    Picker("", selection: $counterCategoryId, content: {
-                        Text("none").tag("")
-                        ForEach(categories) { category in
-                            Text(category.name).tag(category.id)
+                    Picker("", selection: $counterSelection, content: {
+                        Section {
+                            Text("None").tag(SearchCategory.counterNone)
+                            Text("My team").tag(SearchCategory.counterMyTeam)
+                        }
+                        Section {
+                            ForEach(categories) { category in
+                                Text(category.name.isEmpty ? "(unnamed)" : category.name).tag(category.id)
+                            }
                         }
                     })
                     .labelsHidden()
-                    .pickerStyle(RadioGroupPickerStyle())
+                    .pickerStyle(MenuPickerStyle())
+                    .frame(width: 200)
                 }
             }
             .padding(8)
@@ -228,7 +175,7 @@ struct PreferencesView: View {
                         .disableAutocorrection(true)
                         .textContentType(.password)
                         .frame(width: 380)
-                  
+
                 }
                 Text("See the GitHub [search documentation](https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax) for more information on advanced queries")
                     .font(.footnote)
@@ -239,9 +186,75 @@ struct PreferencesView: View {
                 .tabItem{Text("Advanced")}
 
         }
-        .frame(width: 600)
+        .frame(width: 780)
         .padding()
 
+    }
+
+    /// Categories management tab: a scrollable, reorderable list of categories
+    /// with per-row name/filter editing and deletion, plus a "+" menu to add
+    /// builtin templates or a blank custom category.
+    private var categoriesTab: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Categories appear in the menu in this order. Drag to reorder.")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+            List {
+                ForEach($categories) { $category in
+                    HStack(spacing: 8) {
+                        Image(systemName: "line.3.horizontal")
+                            .foregroundColor(.secondary)
+                            .help("Drag to reorder")
+                        TextField("name", text: $category.name)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .frame(width: 150)
+                        TextField("filter, e.g. review-requested:@me", text: $category.filter)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .frame(maxWidth: .infinity)
+                        Button {
+                            categories.removeAll { $0.id == category.id }
+                        } label: {
+                            Image(systemName: "trash")
+                        }
+                        .buttonStyle(BorderlessButtonStyle())
+                        .help("Delete category")
+                    }
+                    .padding(.vertical, 2)
+                }
+                .onMove { indices, newOffset in
+                    categories.move(fromOffsets: indices, toOffset: newOffset)
+                }
+                .onDelete { offsets in
+                    categories.remove(atOffsets: offsets)
+                }
+            }
+            .frame(height: 260)
+
+            HStack(spacing: 8) {
+                Menu {
+                    ForEach(BuiltinTemplate.allCases) { template in
+                        Button(template.name) {
+                            categories.append(template.makeCategory(id: UUID().uuidString))
+                        }
+                    }
+                    Divider()
+                    Button("Custom") {
+                        categories.append(SearchCategory(id: UUID().uuidString, name: "", filter: ""))
+                    }
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .frame(width: 60)
+
+                Text("Use \(SearchCategory.usernamePlaceholder) in a filter to insert your username.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                Spacer()
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
     }
 }
 


### PR DESCRIPTION
* Add ability to have custom queries/listings in the menu (called "Categories")
* Users can drag to reorder and customize the name
* Categories can be displayed as a submenu

---

**New categories tab in settings**

<img width="924" height="607" alt="Screenshot 2026-08-11 at 13 44 37" src="https://github.com/user-attachments/assets/035aadc0-3f1a-4a59-9ce4-a13cd719ffa9" />

* The previous builtins are now accessible from the ➕ (add) dropdown
  * With the addition of a new one: "Review Requested (Direct)", which uses the query `user-review-requested:<username>` to only show PRs directly assigned (not via a team)
* Previously selections are automatically migrated

---

**Change to counter option in Menubar item tab**

<img width="924" height="542" alt="Screenshot 2026-08-11 at 13 48 57" src="https://github.com/user-attachments/assets/42120121-b358-485f-b1e0-3b7cbfa47af0" />

* Now shows all the categories in the dropdown, as well as the existing builtins ("None" and "My team")

---

**Show in submenu**

Categories can can show items as a submenu, they appear like:

<img width="194" height="222" alt="Screenshot 2026-08-11 at 13 48 47" src="https://github.com/user-attachments/assets/a37b889a-9e93-4a78-bc6b-9924f113f0ae" />

This solves a problem for me where I want see PRs I need to review at a glance, but Created/Assigned as secondary so I can review if necessary.